### PR TITLE
환경을 나누는 함수를 수정했습니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist
 node_modules
 .DS_Store
 .env
+.env.*
 .idea
 .next
 out

--- a/examples/sdk-react/package.json
+++ b/examples/sdk-react/package.json
@@ -4,7 +4,10 @@
   "version": "1.13.6",
   "scripts": {
     "dev": "vite --port 3012",
-    "build": "vite build"
+    "build": "vite build",
+    "run:dev": "vite --port 3012 --mode development",
+    "run:stage": "vite --port 3012 --mode stage",
+    "run:prod": "vite --port 3012 --mode production"
   },
   "dependencies": {
     "@to-nexus/sdk": "workspace:*",

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -2172,12 +2172,15 @@ export class AppKit {
       console.error(...args)
     })
 
-    const injectedEnv = getEnv()
-    type EnvKey = keyof typeof ConstantsUtil.VERIFY_URL
-    const envKey = injectedEnv.toUpperCase() as EnvKey
-    const verifyUrl = ConstantsUtil.VERIFY_URL[envKey]
-    const relayUrl = ConstantsUtil.RELAY_URL[envKey]
-    console.log(`injected env from your project: ${injectedEnv}`)
+    const envKey = getEnv().toUpperCase()
+    const verifyUrl =
+      (ConstantsUtil as any).getVerifyUrl?.() ||
+      (ConstantsUtil as any).VERIFY_URL?.[envKey] ||
+      'http://cross-verify.crosstoken.io'
+    const relayUrl =
+      (ConstantsUtil as any).getRelayUrl?.() ||
+      (ConstantsUtil as any).RELAY_URL?.[envKey] ||
+      'wss://cross-relay.crosstoken.io/ws'
 
     const universalProviderOptions: UniversalProviderOpts = {
       projectId: this.options?.projectId,

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -127,10 +127,16 @@ interface AppKitOptionsWithSdk extends AppKitOptions {
 
 // -- Helpers -------------------------------------------------------------------
 let isInitialized = false
+export enum EnvMode {
+  DEV = 'development',
+  STAGE = 'stage',
+  PROD = 'production'
+}
 
 function getEnv(): string {
   // ✅ Vite 환경 (import.meta.env.MODE 사용)
   if (import.meta?.env?.['VITE_ENV_MODE']) {
+    console.log('getEnv(), import.meta.env', import.meta.env)
     console.log('getEnv(), import.meta.env.VITE_ENV_MODE', import.meta.env['VITE_ENV_MODE'])
 
     return import.meta.env['VITE_ENV_MODE']
@@ -151,10 +157,9 @@ function getEnv(): string {
   }
 
   // ✅ 브라우저에서 직접 주입된 환경 변수 (globalThis 사용)
-
   console.log('getEnv(), development')
 
-  return 'development'
+  return 'production'
 }
 
 // -- Client --------------------------------------------------------------------
@@ -2168,6 +2173,10 @@ export class AppKit {
     })
 
     const injectedEnv = getEnv()
+    type EnvKey = keyof typeof ConstantsUtil.VERIFY_URL
+    const envKey = injectedEnv.toUpperCase() as EnvKey
+    const verifyUrl = ConstantsUtil.VERIFY_URL[envKey]
+    const relayUrl = ConstantsUtil.RELAY_URL[envKey]
     console.log(`injected env from your project: ${injectedEnv}`)
 
     const universalProviderOptions: UniversalProviderOpts = {
@@ -2177,17 +2186,13 @@ export class AppKit {
         description: this.options?.metadata ? this.options?.metadata.description : '',
         url: this.options?.metadata ? this.options?.metadata.url : '',
         icons: this.options?.metadata ? this.options?.metadata.icons : [''],
-        verifyUrl:
-          injectedEnv === 'development'
-            ? ConstantsUtil.VERIFY_URL_DEV
-            : ConstantsUtil.VERIFY_URL_PROD,
+        verifyUrl,
         redirect: {
           universal: this.options?.metadata?.redirect?.universal
         }
       },
       logger,
-      relayUrl:
-        injectedEnv === 'development' ? ConstantsUtil.RELAY_URL_DEV : ConstantsUtil.RELAY_URL_PROD
+      relayUrl
     }
 
     console.log(`relayUrl: ${universalProviderOptions.relayUrl}`)

--- a/packages/common/src/utils/ConstantsUtil.ts
+++ b/packages/common/src/utils/ConstantsUtil.ts
@@ -41,7 +41,7 @@ export const ConstantsUtil = {
   },
   RELAY_URL: {
     DEVELOPMENT: 'wss://dev-cross-relay.crosstoken.io/ws',
-    STAGE: 'wss://cross-relay.crosstoken.io/ws',
+    STAGE: 'wss://stg-cross-relay.crosstoken.io/ws',
     PRODUCTION: 'wss://cross-relay.crosstoken.io/ws'
   },
   getVerifyUrl() {

--- a/packages/common/src/utils/ConstantsUtil.ts
+++ b/packages/common/src/utils/ConstantsUtil.ts
@@ -1,6 +1,7 @@
 import type { ChainNamespace } from './TypeUtil.js'
 
 function getEnv(): string {
+  console.log('ConstantUtil.ts getEnv(), import.meta.env', import.meta.env)
   if (typeof import.meta !== 'undefined' && import.meta.env?.['VITE_ENV_MODE']) {
     return import.meta.env['VITE_ENV_MODE']
   }
@@ -13,22 +14,47 @@ function getEnv(): string {
     return process.env['NODE_ENV']
   }
 
-  return 'development'
+  return 'production'
 }
 
 export const ConstantsUtil = {
   WC_NAME_SUFFIX: '.reown.id',
   WC_NAME_SUFFIX_LEGACY: '.wcn.id',
-  BLOCKCHAIN_API_RPC_URL: 'https://testnet.crosstoken.io:22001',  // todo: why not provide mainnet option?
-  PULSE_API_URL: 'https://pulse.walletconnect.org',   // todo: remove this
-  W3M_API_URL:
-    getEnv() === 'development'
-      ? 'https://wallet-server.crosstoken.io'   // no need to use dev-wallet-server
-      : 'https://wallet-server.crosstoken.io',
-  RELAY_URL_DEV: 'wss://cross-relay.crosstoken.io/ws',  // no need to use dev-cross-relay
-  RELAY_URL_PROD: 'wss://cross-relay.crosstoken.io/ws',
-  VERIFY_URL_DEV: 'http://cross-verify.crosstoken.io',  // no need to use dev-cross-verify
-  VERIFY_URL_PROD: 'http://cross-verify.crosstoken.io',
+  BLOCKCHAIN_API_RPC_URL: 'https://testnet.crosstoken.io:22001', // todo: why not provide mainnet option?
+  PULSE_API_URL: 'https://pulse.walletconnect.org', // todo: remove this
+  getWeb3mApiUrl() {
+    const injectedEnv = getEnv()
+    type EnvKey = keyof typeof ConstantsUtil.W3M_API_URL
+    const envKey = injectedEnv.toUpperCase() as EnvKey
+    return ConstantsUtil.W3M_API_URL[envKey]
+  },
+  W3M_API_URL: {
+    DEVELOPMENT: 'https://wallet-server.crosstoken.io',
+    STAGE: 'https://wallet-server.crosstoken.io',
+    PRODUCTION: 'https://wallet-server.crosstoken.io'
+  },
+  getRelayUrl() {
+    const injectedEnv = getEnv()
+    type EnvKey = keyof typeof ConstantsUtil.RELAY_URL
+    const envKey = injectedEnv.toUpperCase() as EnvKey
+    return ConstantsUtil.RELAY_URL[envKey]
+  },
+  RELAY_URL: {
+    DEVELOPMENT: 'wss://dev-cross-relay.crosstoken.io/ws',
+    STAGE: 'wss://cross-relay.crosstoken.io/ws',
+    PRODUCTION: 'wss://cross-relay.crosstoken.io/ws'
+  },
+  getVerifyUrl() {
+    const injectedEnv = getEnv()
+    type EnvKey = keyof typeof ConstantsUtil.VERIFY_URL
+    const envKey = injectedEnv.toUpperCase() as EnvKey
+    return ConstantsUtil.VERIFY_URL[envKey]
+  },
+  VERIFY_URL: {
+    DEVELOPMENT: 'http://cross-verify.crosstoken.io',
+    STAGE: 'http://cross-verify.crosstoken.io',
+    PRODUCTION: 'http://cross-verify.crosstoken.io'
+  },
   /* Connector IDs */
   CONNECTOR_ID: {
     WALLET_CONNECT: 'cross_wallet',

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -255,7 +255,7 @@ export const CoreHelperUtil = {
   },
 
   getApiUrl() {
-    return CommonConstants.W3M_API_URL
+    return CommonConstants.getWeb3mApiUrl()
   },
 
   getBlockchainApiUrl() {


### PR DESCRIPTION
## AS-IS
* 환경을 development / production 2개만 선택 가능 했음
* 환경에 따라 분리되는 것은 relay서버의 URL만임

## TO-BE
* 환경을 development / stage / production 3개로 새분화 하고
* 사용자가 설정을 안했을때 production만을 바라보게 수정함
* 환경에 따라 분리되는 것은 relay서버의 URL만임 (이전과 동일)