### PR TITLE
fix(sdk): allow restricting registered networks via initCrossSdk `networks` option

### DIFF
--- a/.changeset/init-cross-sdk-networks-option.md
+++ b/.changeset/init-cross-sdk-networks-option.md
@@ -1,0 +1,16 @@
+---
+'@to-nexus/sdk': patch
+---
+
+Add an optional `networks` parameter to `initCrossSdk` / `initCrossSdkWithParams`.
+
+Previously the SDK always registered the full built-in network list
+(`networkController.getNetworks()`) with AppKit regardless of the chains a
+dApp actually wanted. Because every chain (including Kaia testnet, id `1001`)
+was registered and requested in the WalletConnect session, the active network
+could resolve to — or be restored from storage as — an unintended chain even
+when `defaultNetwork` was set to CROSS.
+
+Callers can now pass an explicit `networks` list to restrict the dApp to
+specific chains. When omitted, the previous behavior (full built-in list) is
+preserved, so this change is backward compatible.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -86,6 +86,13 @@ export type CrossSdkParams = {
   adapters?: ChainAdapter[]
   mobileLink?: string
   siwx?: SIWXConfig
+  /**
+   * Networks to register with AppKit. When omitted, every network from
+   * `networkController.getNetworks()` is registered (legacy behavior).
+   * Pass an explicit list to restrict the dApp to specific chains so the
+   * active/requested network can never resolve to an unwanted chain.
+   */
+  networks?: SupportedNetworks[]
 }
 
 // 싱글톤 인스턴스 및 초기화 파라미터 저장
@@ -107,7 +114,8 @@ const initCrossSdkWithParams = (params: CrossSdkParams) => {
     defaultNetwork,
     adapters,
     mobileLink,
-    siwx
+    siwx,
+    networks
   } = params
 
   // 파라미터 캐시 저장
@@ -122,7 +130,8 @@ const initCrossSdkWithParams = (params: CrossSdkParams) => {
     defaultNetwork,
     adapters,
     mobileLink,
-    siwx
+    siwx,
+    networks
   )
 
   return sdkInstance
@@ -137,7 +146,8 @@ const initCrossSdk = (
   defaultNetwork?: SupportedNetworks,
   adapters?: ChainAdapter[],
   mobileLink?: string,
-  siwx?: SIWXConfig
+  siwx?: SIWXConfig,
+  networks?: SupportedNetworks[]
 ) => {
   const mergedMetadata = {
     ...defaultMetadata,
@@ -188,10 +198,14 @@ const initCrossSdk = (
     Object.assign(crossWalletConfig, { mobile_link: resolvedMobileLink })
   }
 
+  // Use the caller-supplied networks when provided; otherwise fall back to the full built-in list.
+  const resolvedNetworks =
+    networks && networks.length > 0 ? networks : networkController.getNetworks()
+
   return createAppKit({
     adapters: adapters && adapters.length > 0 ? adapters : [ethersAdapter],
     networks: [
-      ...networkController.getNetworks()
+      ...resolvedNetworks
       // 타입 호환성을 위해 튜플로 변환이 필요할 수 있으나, createAppKit이 배열을 받으므로 spread로 처리
     ] as [any, ...any[]],
     defaultNetwork,

--- a/packages/sdk/src/react.ts
+++ b/packages/sdk/src/react.ts
@@ -98,6 +98,13 @@ export type CrossSdkParams = {
   adapters?: ChainAdapter[]
   mobileLink?: string
   siwx?: SIWXConfig
+  /**
+   * Networks to register with AppKit. When omitted, every network from
+   * `networkController.getNetworks()` is registered (legacy behavior).
+   * Pass an explicit list to restrict the dApp to specific chains so the
+   * active/requested network can never resolve to an unwanted chain.
+   */
+  networks?: SupportedNetworks[]
 }
 
 const initCrossSdkWithParams = (params: CrossSdkParams) => {
@@ -109,7 +116,8 @@ const initCrossSdkWithParams = (params: CrossSdkParams) => {
     defaultNetwork,
     adapters,
     mobileLink,
-    siwx
+    siwx,
+    networks
   } = params
 
   return initCrossSdk(
@@ -120,7 +128,8 @@ const initCrossSdkWithParams = (params: CrossSdkParams) => {
     defaultNetwork,
     adapters,
     mobileLink,
-    siwx
+    siwx,
+    networks
   )
 }
 
@@ -133,7 +142,8 @@ const initCrossSdk = (
   defaultNetwork?: SupportedNetworks,
   adapters?: ChainAdapter[],
   mobileLink?: string,
-  siwx?: SIWXConfig
+  siwx?: SIWXConfig,
+  networks?: SupportedNetworks[]
 ) => {
   const mergedMetadata = {
     ...defaultMetadata,
@@ -173,9 +183,13 @@ const initCrossSdk = (
     Object.assign(crossWalletConfig, { mobile_link: resolvedMobileLink })
   }
 
+  // Use the caller-supplied networks when provided; otherwise fall back to the full built-in list.
+  const resolvedNetworks =
+    networks && networks.length > 0 ? networks : networkController.getNetworks()
+
   return createAppKit({
     adapters: adapters && adapters.length > 0 ? adapters : [ethersAdapter],
-    networks: [...networkController.getNetworks()] as [any, ...any[]],
+    networks: [...resolvedNetworks] as [any, ...any[]],
     defaultNetwork,
     metadata: mergedMetadata,
     projectId,


### PR DESCRIPTION
## 문제 (chainId가 1001/Kaia로 바뀌는 버그)

`initCrossSdk` / `initCrossSdkWithParams`는 dApp이 실제로 사용하려는 체인과 무관하게 **항상 SDK 내장 전체 네트워크 목록**(`networkController.getNetworks()`)을 AppKit에 등록합니다.

```ts
// packages/sdk/src/{react,index}.ts (기존)
networks: [...networkController.getNetworks()]  // cross/bsc/kaia/ether/ronin 전부
```

그 결과:
- Kaia testnet(`1001`)을 포함한 모든 체인이 AppKit에 등록되고 WalletConnect 세션 제안(requestedCaipNetworks)에 실립니다.
- 활성 네트워크는 `defaultNetwork`가 아니라 `ChainController.initialize`가 localStorage(`ACTIVE_CAIP_NETWORK_ID`)에서 복원하므로, 한 번 Kaia가 활성화되면 `defaultNetwork: CROSS` 설정에도 불구하고 **요청이 계속 1001로 라우팅**됩니다.

dApp이 `[CROSS, BSC]`만 쓰도록 어댑터를 구성해도 이 목록을 제한할 방법이 없었습니다.

## 변경

`initCrossSdk` / `initCrossSdkWithParams` / `CrossSdkParams`에 선택적 `networks` 파라미터를 추가했습니다.

```ts
const resolvedNetworks =
  networks && networks.length > 0 ? networks : networkController.getNetworks()

createAppKit({ networks: [...resolvedNetworks], defaultNetwork, ... })
```

- `networks`를 넘기면 해당 체인들만 AppKit에 등록 → Kaia 등 원치 않는 체인이 활성/요청 대상이 될 수 없음.
- **생략 시 기존과 동일하게 전체 목록 사용 → 하위 호환.**
- 위치 인자로는 마지막(9번째)에 추가해 기존 positional 호출에 영향 없음.

`react.ts`(React 진입점)와 `index.ts`(HTML/CDN 진입점) 양쪽에 동일 적용.

## 검증

- `pnpm --filter @to-nexus/sdk typecheck` ✅ 통과
- `pnpm --filter @to-nexus/sdk build` ✅ 성공
- `lint` 에러 수 변동 없음 (49 → 49, 신규 위반 0; `max-params`는 기존부터 위반 중인 룰)
- changeset 추가 (`@to-nexus/sdk`: patch)

## 후속

`@nexus-cross/connect-kit-wagmi`의 `toNexusAdapter`에서 `initCrossSdk(..., networks: caipNetworks)`로 어댑터 구성 네트워크를 전달하면 소비 앱(cross-rewards-frontend 등)에서 1001 문제가 해소됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)